### PR TITLE
Remove ::class uses (PHP 5.4 compatibility)

### DIFF
--- a/Tests/AbstractCustomerGroupTest.php
+++ b/Tests/AbstractCustomerGroupTest.php
@@ -120,8 +120,8 @@ abstract class AbstractCustomerGroupTest extends ContainerAwareTestCase
             new CustomerAction(
                 $securityContext,
                 new MailerFactory(
-                    $this->getMock(EventDispatcherInterface::class),
-                    $this->getMock(ParserInterface::class)
+                    $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'),
+                    $this->getMock('Thelia\Core\Template\ParserInterface')
                 )
             )
         );
@@ -233,7 +233,7 @@ abstract class AbstractCustomerGroupTest extends ContainerAwareTestCase
         $moduleConfigPath = $modulePath . DIRECTORY_SEPARATOR . "Config";
 
         $stubModule = $this
-            ->getMockBuilder(Module::class)
+            ->getMockBuilder('Thelia\Model\Module')
             ->getMock();
 
         $stubModule->method("getAbsoluteBaseDir")->willReturn($modulePath);

--- a/Tests/Event/CustomerGroupEventsTest.php
+++ b/Tests/Event/CustomerGroupEventsTest.php
@@ -10,6 +10,8 @@ use CustomerGroup\Tests\AbstractCustomerGroupTest;
  */
 class CustomerGroupEventsTest extends AbstractCustomerGroupTest
 {
+    const MODULE_EVENTS_CLASS = 'CustomerGroup\Event\CustomerGroupEvents';
+
     /**
      * Assert that a class has a constant.
      * @param string $constantName Expected constant name.
@@ -27,7 +29,7 @@ class CustomerGroupEventsTest extends AbstractCustomerGroupTest
      */
     public function testDefinesAllModuleEvents()
     {
-        $this->assertClassHasConstant("CREATE_CUSTOMER_GROUP", CustomerGroupEvents::class);
-        $this->assertClassHasConstant("ADD_CUSTOMER_TO_CUSTOMER_GROUP", CustomerGroupEvents::class);
+        $this->assertClassHasConstant("CREATE_CUSTOMER_GROUP", static::MODULE_EVENTS_CLASS);
+        $this->assertClassHasConstant("ADD_CUSTOMER_TO_CUSTOMER_GROUP", static::MODULE_EVENTS_CLASS);
     }
 }

--- a/Tests/EventListener/ModuleEventListenerTest.php
+++ b/Tests/EventListener/ModuleEventListenerTest.php
@@ -27,7 +27,7 @@ class ModuleEventListenerTest extends AbstractCustomerGroupTest
 
         // get a mock ConfigurationFileHandler
         $this->configurationFileHandler = $this
-            ->getMockBuilder(ConfigurationFileHandler::class)
+            ->getMockBuilder('CustomerGroup\Handler\ConfigurationFileHandler')
             ->setMethods([
                 "loadConfigurationFile"
             ])


### PR DESCRIPTION
Only tests were affected.
